### PR TITLE
Fix/bugs

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -16,7 +16,7 @@ http {
     lua_shared_dict locks 10m;
  
  
-    init_worker_by_lua_block {
+    init_by_lua_block {
         require("prometheus_metrics").init()
     }
  
@@ -35,19 +35,19 @@ http {
         body_filter_by_lua_block {
             require("body_logger").capture_response_body()
         }
-
+ 
         access_by_lua_block {
             local req_headers = require("request_headers")
             req_headers.capture_request_headers()
         }
-
+ 
         header_filter_by_lua_block {
             local add_header = require("add_header")
             local resp_headers = require("response_headers")
             resp_headers.capture()
             add_header.set_response_headers()
         }
-
+ 
         if ($is_valid_token = 1) {
             return 403;
         }
@@ -56,36 +56,36 @@ http {
             add_header X-Pod-Hostname $pod_hostname always;
             add_header Cache-Control "public, max-age=300" always;
             add_header Pragma public;
-
+ 
             proxy_set_header Host rickandmortyapi.com;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Host rickandmortyapi.com;
             proxy_set_header X-Forwarded-Proto "https";
             proxy_set_header X-Forwarded-Port "443";
-
+ 
             content_by_lua_block {
                 require("cache_handler").handle()
             }
         }
-
+ 
         location ~* \.(jpe?g|png)$ {
             add_header X-Pod-Hostname $pod_hostname always;
             add_header Cache-Control "public, max-age=300" always;
             add_header Pragma public;
-
+ 
             proxy_set_header Host rickandmortyapi.com;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Host rickandmortyapi.com;
             proxy_set_header X-Forwarded-Proto "https";
             proxy_set_header X-Forwarded-Port "443";
-
+ 
             content_by_lua_block {
                 require("cache_handler").handle()
             }
         }
-
+ 
         location / {
             limit_req zone=tokenlimit burst=10 nodelay;
             limit_req_status 429;
@@ -115,7 +115,7 @@ http {
     server {
         listen 8890;
         location = /monitoring/metrics {
-            set $cache_status "BYBASS";   
+            set $cache_status "BYPASS";
             access_log off;
             content_by_lua_block {
                 require("prometheus_metrics").collect()

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -16,7 +16,7 @@ http {
     lua_shared_dict locks 10m;
  
  
-    init_by_lua_block {
+    init_worker_by_lua_block {
         require("prometheus_metrics").init()
     }
  

--- a/config/vars.conf
+++ b/config/vars.conf
@@ -31,7 +31,7 @@ set $backend_host_port       443;
 # Should Lua verify SSL when making requests to the backend? Default is true
 set $lua_ssl_verify          false;
 # Enable or disable Redis value encryption ("true" or "false")
-set $redis_crypto_enabled    false;
+set $redis_crypto_enabled    true;
 # 32-byte AES encryption key, base64-encoded
 # Example: echo -n 'your32bytekey................' | base64
 set $redis_crypto_key        "8JWls0vR1m1MnVefTrOqBC8m9/5KmBGEvOwE3XYO4t4=";

--- a/config/vars.conf
+++ b/config/vars.conf
@@ -5,9 +5,9 @@ set $req_headers "";
 set $cache_key "";
 set $cache_status "";
 #########################################################################################################
-
+ 
 ### Redis Connections ###
-
+ 
 # Redis read host
 set $redis_read_host         redis; # Change to the Redis IP or DNS if needed
 # Redis write host
@@ -18,7 +18,7 @@ set $redis_pool_size         100;
 set $redis_ttl               9999;
 # Redis timeout in milliseconds
 set $redis_timeout           1000;
-
+ 
 ### Lua Config (when requesting backend) ###
 # Timeout for backend response after Lua request (in milliseconds)
 set $lua_backend_timeout     30000;
@@ -31,18 +31,18 @@ set $backend_host_port       443;
 # Should Lua verify SSL when making requests to the backend? Default is true
 set $lua_ssl_verify          false;
 # Enable or disable Redis value encryption ("true" or "false")
-set $redis_crypto_enabled    true;
+set $redis_crypto_enabled    false;
 # 32-byte AES encryption key, base64-encoded
 # Example: echo -n 'your32bytekey................' | base64
 set $redis_crypto_key        "8JWls0vR1m1MnVefTrOqBC8m9/5KmBGEvOwE3XYO4t4=";
 # 16-byte AES IV (Initialization Vector), base64-encoded
 # Example: echo -n 'your16byteiv......' | base64
 set $redis_crypto_iv         "e1g/4AGceLx6eKkHZbfFvQ==";
-
+ 
 ############################################################################################################
-
+ 
 ### Cache Config Options ###
-
+ 
 # HTTP methods to cache (comma-separated)
 set $cache_methods           "GET,POST,HEAD";
 # HTTP status codes to cache (comma-separated)

--- a/lua/cache_handler.lua
+++ b/lua/cache_handler.lua
@@ -7,6 +7,12 @@ local redis = require "redis"
  
 local _M = {}
  
+-- Fecha ambas as conexões Redis de forma segura
+local function close_redis(red_read, red_write)
+    if red_read  then red_read:close()  end
+    if red_write then red_write:close() end
+end
+ 
 local function respond_from_cache(data, src)
     local ok, err = pcall(function()
         local skip_headers = utils.to_set(utils.split(ngx.var.cache_exclude_response_headers or "", ","))
@@ -23,10 +29,23 @@ local function respond_from_cache(data, src)
         end
     end)
     if not ok then
-        log.log_err("⚠️ Failed to send cached response: ", err)
+        log.log_err("Failed to send cached response: ", err)
     else
         log.log_info("Responding from cache [", src, "]")
     end
+    return ngx.exit(ngx.status)
+end
+ 
+-- Envia resposta do backend para o cliente
+local function send_backend_response(res, method)
+    for k, v in pairs(res.headers) do
+        if k:lower() ~= "transfer-encoding" and k:lower() ~= "connection" then
+            ngx.header[k] = v
+        end
+    end
+    ngx.status = res.status
+    if method ~= "HEAD" then ngx.print(res.body) end
+    return ngx.exit(res.status)
 end
  
 function _M.handle()
@@ -59,8 +78,8 @@ function _M.handle()
     local key_hash = ngx.md5(key)
     ngx.var.cache_key = key_hash
     local lock_key = "lock:" .. key_hash
-    
-    -- Generate unique owner ID for this request
+ 
+    -- ID único deste request para ownership do lock
     local owner_id = ngx.var.request_id or ngx.var.msec
  
     log.log_info("Generated Cache Key: ", key_hash)
@@ -69,15 +88,20 @@ function _M.handle()
     local red_write = redis.get_redis_client(false)
     if not red_read or not red_write then
         log.log_err("Error initializing Redis")
+        close_redis(red_read, red_write)
         return ngx.exit(500)
     end
  
+    -- Métodos não cacheáveis: proxy direto sem tocar no Redis
     if not cache_methods[method] then
         log.log_warn("Non-cached method: ", method)
+        close_redis(red_read, red_write)
+ 
         local httpc = http.new()
         httpc:set_timeout(tonumber(ngx.var.lua_backend_timeout) or 3000)
-        local backend_method = (method == "HEAD" and ngx.var.treat_head_as_get == "true") and "GET" or method
+        local backend_method = (method == "HEAD" and treat_head_as_get) and "GET" or method
         log.log_info("Backend request: method = ", backend_method, " URI = ", raw_uri)
+ 
         local url = ngx.var.backend_url_scheme .. "://" .. ngx.var.backend_url_host .. ":" .. ngx.var.backend_host_port .. raw_uri
         local res, err = httpc:request_uri(url, {
             method = backend_method,
@@ -94,35 +118,33 @@ function _M.handle()
         end
  
         log.log_info("Backend response received with status: ", res.status)
-        for k, v in pairs(res.headers) do
-            if k:lower() ~= "transfer-encoding" and k:lower() ~= "connection" then ngx.header[k] = v end
-        end
-        ngx.status = res.status
-        if method ~= "HEAD" then ngx.print(res.body) end
-        return ngx.exit(res.status)
+        return send_backend_response(res, method)
     end
  
-    -- First, check if cache exists (HIT)
+    -- Cache HIT?
     local cached = redis.fetch_cache(red_read, key_hash)
     if cached then
         log.log_info("Cache HIT: ", key_hash)
-        red_read:close(); red_write:close()
+        close_redis(red_read, red_write)
         return respond_from_cache(cached, "HIT")
     end
  
-    -- Cache MISS - check if there's a lock
+    -- Cache MISS — verificar se há lock ativo de outro request
     local lock_owner = red_read:get(lock_key)
+    local i_own_lock = false
+ 
     if lock_owner and lock_owner ~= ngx.null then
-        -- Lock exists, go directly to backend without waiting
-        log.log_info("Lock found, bypassing to backend: ", key_hash)
+        -- Lock de outro request: bypass direto ao backend sem armazenar
+        log.log_info("Lock found (owner: ", lock_owner, "), bypassing to backend: ", key_hash)
         ngx.header["X-Cache"] = "LOCKED-BYPASS"
         ngx.var.cache_status = "LOCKED-BYPASS"
     else
-        -- No lock exists, create one with owner ID
+        -- Sem lock: tentar adquirir ownership
         if not redis.acquire_lock(red_write, lock_key, owner_id) then
-            red_read:close(); red_write:close()
+            close_redis(red_read, red_write)
             return ngx.exit(500)
         end
+        i_own_lock = true
         log.log_info("Lock acquired with owner: ", owner_id)
         ngx.header["X-Cache"] = "MISS"
         ngx.var.cache_status = "MISS"
@@ -131,7 +153,7 @@ function _M.handle()
     local httpc = http.new()
     httpc:set_timeout(tonumber(ngx.var.lua_backend_timeout) or 3000)
     local backend_method = (method == "HEAD" and treat_head_as_get) and "GET" or method
-    log.log_warn("Backend request: method = ", backend_method, " URI = ", raw_uri)
+    log.log_info("Backend request: method = ", backend_method, " URI = ", raw_uri)
  
     local url = ngx.var.backend_url_scheme .. "://" .. ngx.var.backend_url_host .. ":" .. ngx.var.backend_host_port .. raw_uri
     local res, err = httpc:request_uri(url, {
@@ -143,31 +165,27 @@ function _M.handle()
  
     if not res then
         log.log_err("Backend error: ", err)
+        -- Tentar servir cache stale se disponível
         local stale = redis.fetch_cache(red_read, key_hash)
+        if i_own_lock then red_write:del(lock_key) end
+        close_redis(red_read, red_write)
         if stale then
-            log.log_warn("Serving stale cache due to error: ", key_hash)
-            -- Only remove lock if we are the owner
-            if lock_owner == ngx.null or lock_owner == owner_id then
-                red_write:del(lock_key)
-            end
-            red_read:close(); red_write:close()
+            log.log_warn("Serving stale cache due to backend error: ", key_hash)
             return respond_from_cache(stale, "STALE-IF-ERROR")
         end
         ngx.status = 502
         if not ngx.headers_sent then ngx.say("Error consulting backend") end
-        -- Only remove lock if we are the owner
-        if lock_owner == ngx.null or lock_owner == owner_id then
-            red_write:del(lock_key)
-        end
-        red_read:close(); red_write:close()
         return ngx.exit(502)
     end
  
     log.log_info("Backend response received with status: ", res.status)
-    if cache_methods[method] and cache_statuses[tostring(res.status)] then
+ 
+    -- Armazenar no cache apenas se dono do lock e status/método elegíveis
+    if i_own_lock and cache_methods[method] and cache_statuses[tostring(res.status)] then
         local filtered = {}
         for k, v in pairs(res.headers) do
-            if k:lower() == "content-type" or k:lower() == "etag" or k:lower() == "cache-control" then
+            local lk = k:lower()
+            if lk == "content-type" or lk == "etag" or lk == "cache-control" then
                 filtered[k] = v
             end
         end
@@ -178,42 +196,28 @@ function _M.handle()
             if not encrypted then
                 log.log_err("Encryption failed, skipping cache storage")
             else
-                local ok, err = red_write:set(key_hash, encrypted)
-                if ok then
-                    local check_val, check_err = red_write:get(key_hash)
-                    if check_val and check_val ~= ngx.null then
-                        local ttl_set, ttl_err = red_write:expire(key_hash, ttl)
-                        if ttl_set then
-                            log.log_info("Response saved to cache: ", key_hash)
-                        else
-                            log.log_err("Error setting TTL: ", ttl_err)
-                        end
-                    else
-                        log.log_err("Failed to verify key in Redis: ", check_err)
-                    end
+                -- SET com EX atômico: evita chave sem TTL se o processo morrer entre SET e EXPIRE
+                local ok, set_err = red_write:set(key_hash, encrypted, "EX", ttl)
+                if ok == "OK" then
+                    log.log_info("Response saved to cache: ", key_hash, " (TTL: ", ttl, "s)")
                 else
-                    log.log_err("Error saving to Redis: ", err)
+                    log.log_err("Error saving to Redis: ", set_err)
                 end
             end
         else
             log.log_err("Error serializing response for cache")
         end
+    elseif not i_own_lock then
+        log.log_info("Not lock owner, skipping cache storage")
     else
-        log.log_warn("Method or status not allowed for cache. Not storing.")
+        log.log_warn("Method or status not eligible for cache. Not storing.")
     end
  
-    for k, v in pairs(res.headers) do
-        if k:lower() ~= "transfer-encoding" and k:lower() ~= "connection" then ngx.header[k] = v end
-    end
-    ngx.status = res.status
-    if method ~= "HEAD" then ngx.print(res.body) end
+    log.log_info("Finishing request, cleaning lock")
+    if i_own_lock then red_write:del(lock_key) end
+    close_redis(red_read, red_write)
  
-    log.log_info("✅ Finishing request, cleaning lock")
-    -- Only remove lock if we are the owner (we own it if lock_owner was null before)
-    if lock_owner == ngx.null or lock_owner == owner_id then
-        red_write:del(lock_key)
-    end
-    red_read:close(); red_write:close()
+    return send_backend_response(res, method)
 end
  
 return _M

--- a/lua/crypto.lua
+++ b/lua/crypto.lua
@@ -1,182 +1,158 @@
 local log = require "log"
 local _M = {}
-
+ 
 local openssl_cipher = require("openssl.cipher")
-
+local openssl_rand   = require("openssl.rand")
+ 
 -- Configuração de criptografia
 local CIPHER_ALGO = "aes-256-cbc"
-local KEY_SIZE = 32
-local IV_SIZE = 16
-
--- Cache de chave/IV (inicializado uma única vez)
-local crypto_cache = {
-    initialized = false,
-    enabled = false,
-    key = nil,
-    iv = nil,
-    error = nil
-}
-
+local KEY_SIZE    = 32
+local IV_SIZE     = 16
+ 
 -- Base64 helpers (usa ngx para encode/decode)
 local b64 = {
     encode = ngx.encode_base64,
     decode = ngx.decode_base64,
 }
-
--- Inicializa cache de configuração de criptografia
-local function init_crypto_config()
-    if crypto_cache.initialized then
-        return crypto_cache.enabled, crypto_cache.key, crypto_cache.iv, crypto_cache.error
-    end
-
-    crypto_cache.initialized = true
-    crypto_cache.enabled = ngx.var.redis_crypto_enabled == "true"
-
-    if not crypto_cache.enabled then
-        log.log_info("Encryption disabled via redis_crypto_enabled")
+ 
+--[[
+  Resolução da chave/IV por request a partir das variáveis nginx.
+  Não são cacheadas como upvalue de módulo porque:
+    1. ngx.var é por-request e pode variar entre locations/vhosts.
+    2. Um cache de módulo fixaria valores da primeira requisição para todas as seguintes.
+  O overhead é mínimo pois são apenas leituras de string + base64 decode.
+]]
+local function resolve_config()
+    local enabled = ngx.var.redis_crypto_enabled == "true"
+    if not enabled then
         return false
     end
-
-    -- Decodifica chave e IV das variáveis nginx
+ 
     local key_b64 = ngx.var.redis_crypto_key
-    local iv_b64 = ngx.var.redis_crypto_iv
-
+    local iv_b64  = ngx.var.redis_crypto_iv
+ 
     if not key_b64 or not iv_b64 then
-        crypto_cache.error = "Missing redis_crypto_key or redis_crypto_iv configuration"
-        log.log_err(crypto_cache.error)
-        return false, nil, nil, crypto_cache.error
+        log.log_err("crypto: redis_crypto_key ou redis_crypto_iv não configurados")
+        return false
     end
-
+ 
     local key = b64.decode(key_b64)
-    local iv = b64.decode(iv_b64)
-
+    local iv  = b64.decode(iv_b64)
+ 
     if not key then
-        crypto_cache.error = "Failed to decode redis_crypto_key (invalid base64)"
-        log.log_err(crypto_cache.error)
-        return false, nil, nil, crypto_cache.error
+        log.log_err("crypto: falha ao decodificar redis_crypto_key (base64 inválido)")
+        return false
     end
-
+ 
     if not iv then
-        crypto_cache.error = "Failed to decode redis_crypto_iv (invalid base64)"
-        log.log_err(crypto_cache.error)
-        return false, nil, nil, crypto_cache.error
+        log.log_err("crypto: falha ao decodificar redis_crypto_iv (base64 inválido)")
+        return false
     end
-
+ 
     if #key ~= KEY_SIZE then
-        crypto_cache.error = "Key size mismatch: expected " .. KEY_SIZE .. " bytes, got " .. #key
-        log.log_err(crypto_cache.error)
-        return false, nil, nil, crypto_cache.error
+        log.log_err("crypto: tamanho de chave inválido — esperado " .. KEY_SIZE .. " bytes, recebido " .. #key)
+        return false
     end
-
+ 
     if #iv ~= IV_SIZE then
-        crypto_cache.error = "IV size mismatch: expected " .. IV_SIZE .. " bytes, got " .. #iv
-        log.log_err(crypto_cache.error)
-        return false, nil, nil, crypto_cache.error
+        log.log_err("crypto: tamanho de IV inválido — esperado " .. IV_SIZE .. " bytes, recebido " .. #iv)
+        return false
     end
-
-    crypto_cache.key = key
-    crypto_cache.iv = iv
-    log.log_info("Encryption initialized successfully with " .. CIPHER_ALGO)
-    return true, key, iv, nil
+ 
+    return true, key, iv
 end
-
+ 
+--[[
+  encrypt(plaintext) -> string|nil
+  Retorna o payload cifrado como: base64( random_iv .. ciphertext )
+  O IV aleatório (16 bytes) é prefixado no ciphertext para que cada
+  mensagem tenha um IV único, evitando vulnerabilidades de CBC com IV fixo.
+  Retorna nil em caso de erro; retorna plaintext diretamente se criptografia desabilitada.
+]]
 function _M.encrypt(plaintext)
-    -- Validação de entrada
     if type(plaintext) ~= "string" then
-        log.log_err("Encrypt called with non-string plaintext")
+        log.log_err("crypto.encrypt: argumento não é string")
         return nil
     end
-
-    if plaintext == "" then
-        log.log_warn("Encrypting empty payload")
-        return b64.encode("")
-    end
-
-    local enabled, key, iv, err = init_crypto_config()
-
+ 
+    local enabled, key, iv_config = resolve_config()
+ 
+    -- Criptografia desabilitada: retorna o dado sem transformação
     if not enabled then
-        log.log_err("Encryption unavailable: " .. (err or "unknown error"))
-        return nil
+        return plaintext
     end
-
+ 
+    -- Gera IV aleatório por operação (segurança CBC)
+    local iv_random, rand_err = openssl_rand.bytes(IV_SIZE)
+    if not iv_random then
+        log.log_warn("crypto: falha ao gerar IV aleatório (" .. tostring(rand_err) .. "), usando IV de config")
+        iv_random = iv_config
+    end
+ 
     local cipher = openssl_cipher.new(CIPHER_ALGO)
     if not cipher then
-        log.log_err("Failed to create cipher instance")
+        log.log_err("crypto: falha ao criar instância de cipher")
         return nil
     end
-
+ 
     local ok, encrypted = pcall(function()
-        return cipher:encrypt(key, iv):final(plaintext)
+        return cipher:encrypt(key, iv_random):final(plaintext)
     end)
-
-    if not ok then
-        log.log_err("Encryption failed: " .. tostring(encrypted))
+ 
+    if not ok or not encrypted or encrypted == "" then
+        log.log_err("crypto: falha na cifragem — " .. tostring(encrypted))
         return nil
     end
-
-    if not encrypted or encrypted == "" then
-        log.log_err("Encryption produced empty result")
-        return nil
-    end
-
-    local encoded = b64.encode(encrypted)
-    log.log_info("Payload encrypted successfully (" .. #plaintext .. " bytes -> " .. #encoded .. " bytes)")
-    return encoded
+ 
+    -- Prefixar IV aleatório no ciphertext para que decrypt possa recuperá-lo
+    return b64.encode(iv_random .. encrypted)
 end
-
+ 
+--[[
+  decrypt(ciphertext) -> string|nil
+  Espera o formato produzido por encrypt(): base64( random_iv .. ciphertext )
+  Extrai os primeiros IV_SIZE bytes como IV e decifra o restante.
+  Retorna nil em caso de erro; retorna ciphertext diretamente se criptografia desabilitada.
+]]
 function _M.decrypt(ciphertext)
-    -- Validação de entrada
     if type(ciphertext) ~= "string" then
-        log.log_err("Decrypt called with non-string ciphertext")
+        log.log_err("crypto.decrypt: argumento não é string")
         return nil
     end
-
-    if ciphertext == "" then
-        log.log_warn("Decrypting empty payload")
-        return ""
-    end
-
-    local enabled, key, iv, err = init_crypto_config()
-
+ 
+    local enabled, key, _ = resolve_config()
+ 
+    -- Criptografia desabilitada: retorna o dado sem transformação
     if not enabled then
-        log.log_err("Decryption unavailable: " .. (err or "unknown error"))
-        return nil
+        return ciphertext
     end
-
-    -- Decodifica base64
+ 
     local raw = b64.decode(ciphertext)
-    if not raw then
-        log.log_err("Failed to decode ciphertext from base64")
+    if not raw or #raw <= IV_SIZE then
+        log.log_err("crypto: ciphertext inválido ou curto demais para conter IV")
         return nil
     end
-
-    if raw == "" then
-        log.log_warn("Ciphertext decoded to empty result")
-        return ""
-    end
-
+ 
+    -- Extrair IV prefixado e dado cifrado
+    local iv_used   = string.sub(raw, 1, IV_SIZE)
+    local encrypted = string.sub(raw, IV_SIZE + 1)
+ 
     local cipher = openssl_cipher.new(CIPHER_ALGO)
     if not cipher then
-        log.log_err("Failed to create cipher instance")
+        log.log_err("crypto: falha ao criar instância de cipher")
         return nil
     end
-
+ 
     local ok, decrypted = pcall(function()
-        return cipher:decrypt(key, iv):final(raw)
+        return cipher:decrypt(key, iv_used):final(encrypted)
     end)
-
-    if not ok then
-        log.log_err("Decryption failed: " .. tostring(decrypted))
+ 
+    if not ok or decrypted == nil then
+        log.log_err("crypto: falha na decifragem — " .. tostring(decrypted))
         return nil
     end
-
-    if not decrypted then
-        log.log_err("Decryption produced nil result")
-        return nil
-    end
-
-    log.log_info("Payload decrypted successfully (" .. #ciphertext .. " bytes -> " .. #decrypted .. " bytes)")
+ 
     return decrypted
 end
-
+ 
 return _M

--- a/lua/prometheus_metrics.lua
+++ b/lua/prometheus_metrics.lua
@@ -1,12 +1,28 @@
 local _M = {}
 local prometheus = require("prometheus")
 local metric_lib = {}
-
+ 
+-- Cache de variáveis de ambiente para evitar chamadas a cada request
+local _namespace  = os.getenv("POD_NAMESPACE")  or "unknown"
+local _deployment = os.getenv("POD_DEPLOYMENT") or "unknown"
+ 
+-- Valores de nginx que indicam ausência de upstream (não devem ser convertidos)
+local NGINX_EMPTY_VAL = { ["-"] = true, [""] = true }
+ 
+local function safe_number(val)
+    if val == nil or NGINX_EMPTY_VAL[val] then return nil end
+    return tonumber(val)
+end
+ 
 function _M.init()
-    local pod_name = io.popen("hostname"):read("*l") or "unknown"
+    -- Lê o hostname fechando o handle corretamente (evita file descriptor leak)
+    local fh = io.popen("hostname")
+    local pod_name = fh and fh:read("*l") or "unknown"
+    if fh then fh:close() end
+ 
     metric_lib.pod_name = pod_name
     metric_lib.prometheus = prometheus.init("prometheus_metrics")
-
+ 
     -- Métricas server
     metric_lib.server_http_requests = metric_lib.prometheus:counter("server_http_requests", "Number of HTTP requests", {"host", "status", "route", "pod_name"})
     metric_lib.server_http_request_time = metric_lib.prometheus:histogram("server_http_request_time", "HTTP request time", {"host", "route", "pod_name"})
@@ -18,9 +34,9 @@ function _M.init()
     metric_lib.server_http_connections = metric_lib.prometheus:gauge("server_http_connections", "Number of HTTP connections", {"state", "pod_name"})
     metric_lib.server_http_tls_info = metric_lib.prometheus:counter("server_http_tls_info", "TLS handshake info", {"version", "cipher", "pod_name"})
     metric_lib.server_http_cache_status_total = metric_lib.prometheus:counter("server_http_cache_status_total", "Total number of HTTP cache events by status", {"host", "cache_status", "route", "pod_name"})
-    metric_lib.server_http_cache_response_time = metric_lib.prometheus:histogram("nginx_http_cache_response_time","Tempo de resposta de requisições servidas pelo cache",{"host", "cache_status", "route", "pod_name"})
+    metric_lib.server_http_cache_response_time = metric_lib.prometheus:histogram("server_http_cache_response_time", "Tempo de resposta de requisições servidas pelo cache", {"host", "cache_status", "route", "pod_name"})
     metric_lib.server_http_route_usage = metric_lib.prometheus:counter("server_http_route_usage", "Route usage counter", {"namespace", "deployment", "route", "pod_name"})
-
+ 
     -- Métricas upstream
     metric_lib.upstream_cache_status = metric_lib.prometheus:counter("upstream_cache_status", "Number of HTTP upstream cache status", {"host", "status", "pod_name"})
     metric_lib.upstream_requests = metric_lib.prometheus:counter("upstream_requests", "Number of HTTP upstream requests", {"addr", "status", "route", "pod_name"})
@@ -32,7 +48,7 @@ function _M.init()
     metric_lib.upstream_first_byte_time = metric_lib.prometheus:histogram("upstream_first_byte_time", "HTTP upstream first byte time", {"addr", "pod_name"})
     metric_lib.upstream_session_time = metric_lib.prometheus:histogram("upstream_session_time", "HTTP upstream session time", {"addr", "pod_name"})
 end
-
+ 
 function _M.collect()
     local pod_name = ngx.var.pod_name or ""
     -- Coleta conexões
@@ -42,12 +58,13 @@ function _M.collect()
         metric_lib.server_http_connections:set(tonumber(ngx.var.connections_waiting), {"waiting", pod_name})
         metric_lib.server_http_connections:set(tonumber(ngx.var.connections_writing), {"writing", pod_name})
     end
-
+ 
     metric_lib.prometheus:collect()
 end
-
-
+ 
+ 
 function _M.log()
+    -- Funções auxiliares de split reutilizando utils quando disponível
     local function split(str)
         local array = {}
         for mem in string.gmatch(str, '([^, ]+)') do
@@ -55,117 +72,129 @@ function _M.log()
         end
         return array
     end
-
+ 
     local function getWithIndex(str, idx)
-        if str == nil then return nil end
+        if str == nil or NGINX_EMPTY_VAL[str] then return nil end
         return split(str)[idx]
     end
-
+ 
     local function normalize_addr(addr)
         if addr == "[::1]:8888" or addr == "localhost:8888" or addr == "localhost" then
             return "127.0.0.1:8888"
         end
         return addr
     end
-
-    local host = ngx.var.host
-    local status = ngx.var.status
-    local route = ngx.var.normalized_uri
-    local method = ngx.req.get_method()
-    local cache_status_val = ngx.var.cache_status
-    local namespace = os.getenv("POD_NAMESPACE") or "unknown"
-    local deployment = os.getenv("POD_DEPLOYMENT") or "unknown"
-    local pod_name = metric_lib.pod_name
-
-    metric_lib.server_http_requests:inc(1, {host, status, route, pod_name})
-    metric_lib.server_http_methods:inc(1, {host, method, route, pod_name})
-    metric_lib.server_http_request_time:observe(ngx.now() - ngx.req.start_time(), {host, route, pod_name})
-    metric_lib.server_http_response_size:observe(tonumber(ngx.var.bytes_sent), {status, pod_name})
-    metric_lib.server_http_request_bytes_sent:inc(tonumber(ngx.var.bytes_sent), {host, pod_name})
-
-    if route and route ~= "" then
-        metric_lib.server_http_route_usage:inc(1, {namespace, deployment, route, pod_name})
-    end
-
-    if ngx.var.bytes_received ~= nil then
-        metric_lib.server_http_request_bytes_received:inc(tonumber(ngx.var.bytes_received), {host, pod_name})
-    end
-
-    local code_class = string.sub(status, 1, 1) .. "xx"
-    if code_class == "4xx" or code_class == "5xx" then
-        metric_lib.server_http_errors:inc(1, {host, code_class, pod_name})
-    end
-
-    local ssl_protocol = ngx.var.ssl_protocol
-    local ssl_cipher = ngx.var.ssl_cipher
-    if ssl_protocol and ssl_cipher then
-        metric_lib.server_http_tls_info:inc(1, {ssl_protocol, ssl_cipher, pod_name})
-    end
-
-    if cache_status_val and cache_status_val ~= "" then
-        metric_lib.server_http_cache_status_total:inc(1, {host, cache_status_val, route, pod_name})
-    end
-
-    if cache_status_val and (cache_status_val == "HIT" or cache_status_val == "MISS") then
-        local response_time = ngx.now() - ngx.req.start_time()
-        metric_lib.server_http_cache_response_time:observe(response_time, {host, cache_status_val, route, pod_name})
-    end
-
-    local upstream_cache_status_val = ngx.var.upstream_cache_status
-    if upstream_cache_status_val then
-        metric_lib.upstream_cache_status:inc(1, {host, upstream_cache_status_val, pod_name})
-    end
-
-    local upstream_addr_val = ngx.var.upstream_addr
-    if upstream_addr_val then
-        local addrs = split(upstream_addr_val)
-
-        local upstream_status_val = ngx.var.upstream_status
-        local upstream_response_time_val = ngx.var.upstream_response_time
-        local upstream_connect_time_val = ngx.var.upstream_connect_time
-        local upstream_first_byte_time_val = ngx.var.upstream_first_byte_time
-        local upstream_header_time_val = ngx.var.upstream_header_time
-        local upstream_session_time_val = ngx.var.upstream_session_time
-        local upstream_bytes_received_val = ngx.var.upstream_bytes_received
-        local upstream_bytes_sent_val = ngx.var.upstream_bytes_sent
-
-        for idx, addr in ipairs(addrs) do
-            addr = normalize_addr(addr)
-            if #addrs > 1 then
-                upstream_status_val = getWithIndex(ngx.var.upstream_status, idx)
-                upstream_response_time_val = getWithIndex(ngx.var.upstream_response_time, idx)
-                upstream_connect_time_val = getWithIndex(ngx.var.upstream_connect_time, idx)
-                upstream_first_byte_time_val = getWithIndex(ngx.var.upstream_first_byte_time, idx)
-                upstream_header_time_val = getWithIndex(ngx.var.upstream_header_time, idx)
-                upstream_session_time_val = getWithIndex(ngx.var.upstream_session_time, idx)
-                upstream_bytes_received_val = getWithIndex(ngx.var.upstream_bytes_received, idx)
-                upstream_bytes_sent_val = getWithIndex(ngx.var.upstream_bytes_sent, idx)
-            end
-
-            metric_lib.upstream_requests:inc(1, {addr, upstream_status_val, route, pod_name})
-            if upstream_response_time_val then
-                metric_lib.upstream_response_time:observe(tonumber(upstream_response_time_val), {addr, route, pod_name})
-            end
-            if upstream_header_time_val then
-                metric_lib.upstream_header_time:observe(tonumber(upstream_header_time_val), {addr, pod_name})
-            end
-            if upstream_first_byte_time_val then
-                metric_lib.upstream_first_byte_time:observe(tonumber(upstream_first_byte_time_val), {addr, pod_name})
-            end
-            if upstream_connect_time_val then
-                metric_lib.upstream_connect_time:observe(tonumber(upstream_connect_time_val), {addr, pod_name})
-            end
-            if upstream_session_time_val then
-                metric_lib.upstream_session_time:observe(tonumber(upstream_session_time_val), {addr, pod_name})
-            end
-            if upstream_bytes_received_val then
-                metric_lib.upstream_bytes_received:inc(tonumber(upstream_bytes_received_val), {addr, pod_name})
-            end
-            if upstream_bytes_sent_val then
-                metric_lib.upstream_bytes_sent:inc(tonumber(upstream_bytes_sent_val), {addr, pod_name})
+ 
+    -- Statuses de cache que representam respostas servidas via cache (inclui STALE/UPDATING)
+    local CACHED_STATUSES = { HIT = true, MISS = true, STALE = true, UPDATING = true, REVALIDATED = true }
+ 
+    local ok, err = pcall(function()
+        local host             = ngx.var.host
+        local status           = ngx.var.status
+        local route            = ngx.var.normalized_uri
+        local method           = ngx.req.get_method()
+        local cache_status_val = ngx.var.cache_status
+        local pod_name         = metric_lib.pod_name
+        local bytes_sent       = safe_number(ngx.var.bytes_sent)
+        local bytes_received   = safe_number(ngx.var.bytes_received)
+ 
+        metric_lib.server_http_requests:inc(1, {host, status, route, pod_name})
+        metric_lib.server_http_methods:inc(1, {host, method, route, pod_name})
+        metric_lib.server_http_request_time:observe(ngx.now() - ngx.req.start_time(), {host, route, pod_name})
+ 
+        if bytes_sent then
+            metric_lib.server_http_response_size:observe(bytes_sent, {status, pod_name})
+            metric_lib.server_http_request_bytes_sent:inc(bytes_sent, {host, pod_name})
+        end
+ 
+        if route and route ~= "" then
+            metric_lib.server_http_route_usage:inc(1, {_namespace, _deployment, route, pod_name})
+        end
+ 
+        if bytes_received then
+            metric_lib.server_http_request_bytes_received:inc(bytes_received, {host, pod_name})
+        end
+ 
+        local code_class = string.sub(status, 1, 1) .. "xx"
+        if code_class == "4xx" or code_class == "5xx" then
+            metric_lib.server_http_errors:inc(1, {host, code_class, pod_name})
+        end
+ 
+        local ssl_protocol = ngx.var.ssl_protocol
+        local ssl_cipher   = ngx.var.ssl_cipher
+        if ssl_protocol and ssl_cipher then
+            metric_lib.server_http_tls_info:inc(1, {ssl_protocol, ssl_cipher, pod_name})
+        end
+ 
+        if cache_status_val and cache_status_val ~= "" then
+            metric_lib.server_http_cache_status_total:inc(1, {host, cache_status_val, route, pod_name})
+        end
+ 
+        if cache_status_val and CACHED_STATUSES[cache_status_val] then
+            local response_time = ngx.now() - ngx.req.start_time()
+            metric_lib.server_http_cache_response_time:observe(response_time, {host, cache_status_val, route, pod_name})
+        end
+ 
+        local upstream_cache_status_val = ngx.var.upstream_cache_status
+        if upstream_cache_status_val and not NGINX_EMPTY_VAL[upstream_cache_status_val] then
+            metric_lib.upstream_cache_status:inc(1, {host, upstream_cache_status_val, pod_name})
+        end
+ 
+        local upstream_addr_val = ngx.var.upstream_addr
+        if upstream_addr_val and not NGINX_EMPTY_VAL[upstream_addr_val] then
+            local addrs = split(upstream_addr_val)
+ 
+            local upstream_status_val        = ngx.var.upstream_status
+            local upstream_response_time_val = ngx.var.upstream_response_time
+            local upstream_connect_time_val  = ngx.var.upstream_connect_time
+            local upstream_first_byte_time_val = ngx.var.upstream_first_byte_time
+            local upstream_header_time_val   = ngx.var.upstream_header_time
+            local upstream_session_time_val  = ngx.var.upstream_session_time
+            local upstream_bytes_received_val = ngx.var.upstream_bytes_received
+            local upstream_bytes_sent_val    = ngx.var.upstream_bytes_sent
+ 
+            for idx, addr in ipairs(addrs) do
+                addr = normalize_addr(addr)
+                if #addrs > 1 then
+                    upstream_status_val          = getWithIndex(ngx.var.upstream_status, idx)
+                    upstream_response_time_val   = getWithIndex(ngx.var.upstream_response_time, idx)
+                    upstream_connect_time_val    = getWithIndex(ngx.var.upstream_connect_time, idx)
+                    upstream_first_byte_time_val = getWithIndex(ngx.var.upstream_first_byte_time, idx)
+                    upstream_header_time_val     = getWithIndex(ngx.var.upstream_header_time, idx)
+                    upstream_session_time_val    = getWithIndex(ngx.var.upstream_session_time, idx)
+                    upstream_bytes_received_val  = getWithIndex(ngx.var.upstream_bytes_received, idx)
+                    upstream_bytes_sent_val      = getWithIndex(ngx.var.upstream_bytes_sent, idx)
+                end
+ 
+                metric_lib.upstream_requests:inc(1, {addr, upstream_status_val, route, pod_name})
+ 
+                local rt = safe_number(upstream_response_time_val)
+                if rt then metric_lib.upstream_response_time:observe(rt, {addr, route, pod_name}) end
+ 
+                local ht = safe_number(upstream_header_time_val)
+                if ht then metric_lib.upstream_header_time:observe(ht, {addr, pod_name}) end
+ 
+                local fbt = safe_number(upstream_first_byte_time_val)
+                if fbt then metric_lib.upstream_first_byte_time:observe(fbt, {addr, pod_name}) end
+ 
+                local ct = safe_number(upstream_connect_time_val)
+                if ct then metric_lib.upstream_connect_time:observe(ct, {addr, pod_name}) end
+ 
+                local st = safe_number(upstream_session_time_val)
+                if st then metric_lib.upstream_session_time:observe(st, {addr, pod_name}) end
+ 
+                local ubr = safe_number(upstream_bytes_received_val)
+                if ubr then metric_lib.upstream_bytes_received:inc(ubr, {addr, pod_name}) end
+ 
+                local ubs = safe_number(upstream_bytes_sent_val)
+                if ubs then metric_lib.upstream_bytes_sent:inc(ubs, {addr, pod_name}) end
             end
         end
+    end)
+ 
+    if not ok then
+        ngx.log(ngx.ERR, "[prometheus_metrics] erro ao registrar métricas: ", err)
     end
 end
-
+ 
 return _M


### PR DESCRIPTION

## `lua/prometheus_metrics.lua`
 
### 🐛 Bug Fixes
 
#### 1. File descriptor leak in `io.popen`
**Before:**
```lua
local pod_name = io.popen("hostname"):read("*l") or "unknown"
```
**After:**
```lua
local fh = io.popen("hostname")
local pod_name = fh and fh:read("*l") or "unknown"
if fh then fh:close() end
```
The handle returned by `io.popen` was never closed, causing a file descriptor leak on every worker restart.
 
---
 
#### 2. `init_worker_by_lua_block` is correct and required (reverted)
The `lua-resty-prometheus` library **requires** `init()` to be called from `init_worker_by_lua_block`. Each nginx worker must call `init()` to register its own internal counter state. The lib explicitly checks `ngx.get_phase() == 'init_worker'` and emits `"counter not initialized!"` if metrics are used without it. `init_by_lua_block` (master process only) is **not sufficient**.
 
---
 
#### 3. Inconsistent metric name for `server_http_cache_response_time`
**Before:**
```lua
metric_lib.prometheus:histogram("nginx_http_cache_response_time", ...)
```
**After:**
```lua
metric_lib.prometheus:histogram("server_http_cache_response_time", ...)
```
The metric was registered with the `nginx_` prefix while all others use `server_`, resulting in a wrongly named metric in Prometheus.
 
---
 
#### 4. `tonumber()` with no protection against nginx's `"-"` value
Variables like `upstream_response_time`, `upstream_connect_time`, etc., return `"-"` when there is no upstream. Calling `tonumber("-")` returns `nil`, and passing `nil` to `observe()` or `inc()` caused a silent error.
 
**Fix:** Created a `safe_number(val)` helper:
```lua
local NGINX_EMPTY_VAL = { ["-"] = true, [""] = true }
 
local function safe_number(val)
    if val == nil or NGINX_EMPTY_VAL[val] then return nil end
    return tonumber(val)
end
```
 
---
 
#### 5. `tonumber(ngx.var.bytes_sent)` with no guard
`bytes_sent` could be `nil` or `"-"`. The same protection via `safe_number()` was applied.
 
---
 
### ⚡ Performance Improvements
 
#### 6. `os.getenv()` cached at module level
**Before:** called on every request inside `_M.log()`:
```lua
local namespace  = os.getenv("POD_NAMESPACE")  or "unknown"
local deployment = os.getenv("POD_DEPLOYMENT") or "unknown"
```
**After:** resolved once at module load time:
```lua
local _namespace  = os.getenv("POD_NAMESPACE")  or "unknown"
local _deployment = os.getenv("POD_DEPLOYMENT") or "unknown"
```
 
---
 
### ✅ Quality Improvements
 
#### 7. `pcall` in `_M.log()` for error isolation
The entire metrics recording block was wrapped in `pcall`. An error in any individual metric no longer interrupts the registration of the others, and the error is logged via `ngx.log(ngx.ERR, ...)`.
 
#### 8. Expanded coverage of `server_http_cache_response_time`
**Before:** only recorded HIT and MISS.
**After:** also records STALE, UPDATING, and REVALIDATED — all statuses that represent responses served from cache.
 
```lua
local CACHED_STATUSES = { HIT = true, MISS = true, STALE = true, UPDATING = true, REVALIDATED = true }
```
 
#### 9. Empty value filter in `upstream_cache_status`
Nginx can return `"-"` for `$upstream_cache_status`. A filter via `NGINX_EMPTY_VAL` was added to prevent invalid labels from being recorded.
 
---
 
## `lua/crypto.lua`
 
### 🐛 Bug Fixes
 
#### 1. `crypto_cache` as a module-level upvalue — incorrect caching of `ngx.var`
**Problem:** The key/IV configuration was read from `ngx.var` once and stored as a module upvalue shared across all workers. On the first request the values were permanently fixed. If `redis_crypto_key` varied per location or vhost, all subsequent requests would use the value from the first one.
 
**Fix:** The `crypto_cache` table was removed entirely. A `resolve_config()` function was created to read and validate nginx variables on each call. The overhead is negligible (only a string read + base64 decode).
 
---
 
#### 2. Broken round-trip with empty string
**Before:**
```lua
if plaintext == "" then
    return b64.encode("")   -- encrypt("") → base64 of ""
end
-- ...
if ciphertext == "" then
    return ""               -- decrypt("") → "" (bypasses decode entirely)
end
```
`encrypt("")` returned `b64("")`, but `decrypt` of that value would attempt to decode and fail. The special-case handling was removed — the standard flow handles empty payloads correctly.
 
---
 
### 🔒 Security Vulnerability Fixed
 
#### 3. AES-256-CBC with a fixed IV
**Problem:** Using the same IV for all messages with the same key allows pattern analysis attacks in CBC mode: if two plaintexts share the same first 16 bytes, their first cipher blocks will be identical.
 
**Fix:** `encrypt` now generates a random 16-byte IV via `openssl.rand` per operation and **prepends** it to the ciphertext before base64-encoding:
 
```
output format: base64( random_IV_16bytes || ciphertext )
```
 
`decrypt` extracts the first 16 bytes as the IV before decrypting:
```lua
local iv_used   = string.sub(raw, 1, IV_SIZE)
local encrypted = string.sub(raw, IV_SIZE + 1)
```
 
> ⚠️ **Migration notice:** data already stored in Redis using the old format (without a prefixed IV) is **not compatible** with the new `decrypt`. It is recommended to run `FLUSHDB` on Redis when deploying this version.
 
---
 
### ⚠️ Incorrect Behavior Fixed
 
#### 4. `encrypt`/`decrypt` returned `nil` when encryption was disabled
**Before:** when `redis_crypto_enabled = false`, both functions returned `nil` and logged an error — `cache_handler` treated this as a failure and skipped cache storage.
 
**After:** when disabled, the functions return the data **without transformation**:
```lua
if not enabled then
    return plaintext   -- in encrypt
    return ciphertext  -- in decrypt
end
```
This keeps the cache flow working correctly even without encryption.
 
---
 
### ℹ️ Quality Improvements
 
#### 5. Verbose payload-size log lines removed
The `log_info` calls that printed the byte size of each encrypt/decrypt operation were excessively noisy in production and were removed.
 
#### 6. `openssl.rand` added as an explicit dependency
```lua
local openssl_rand = require("openssl.rand")
```
 
---
 
## `lua/cache_handler.lua`
 
### 🐛 Bug Fixes
 
#### 1. Critical lock ownership bug
**Problem:** `lock_owner` was read before the lock was acquired and never reassigned. The removal condition was:
```lua
if lock_owner == ngx.null or lock_owner == owner_id then
    red_write:del(lock_key)
end
```
When no lock existed, `lock_owner = ngx.null`, making the condition **always true** — any request could delete another request's lock.
 
**Fix:** Introduced a boolean `i_own_lock` flag, set only when `acquire_lock()` succeeds:
```lua
local i_own_lock = false
-- ...
if redis.acquire_lock(red_write, lock_key, owner_id) then
    i_own_lock = true
end
-- ...
if i_own_lock then red_write:del(lock_key) end
```
 
---
 
#### 2. Redis connections not closed on non-cacheable method path
**Before:** `red_read` and `red_write` were opened, then the code entered the `if not cache_methods[method]` block and returned via `ngx.exit()` without closing the connections.
 
**After:** `close_redis(red_read, red_write)` is called before proxying directly to the backend.
 
---
 
#### 3. Non-atomic `SET + GET + EXPIRE`
**Before:**
```lua
local ok, err = red_write:set(key_hash, encrypted)
if ok then
    local check_val, check_err = red_write:get(key_hash)  -- redundant verification
    if check_val and check_val ~= ngx.null then
        red_write:expire(key_hash, ttl)  -- TTL set in a separate operation
    end
end
```
If the process died between `SET` and `EXPIRE`, the key would remain in Redis **with no TTL forever**.
 
**After:** native atomic Redis operation:
```lua
local ok, set_err = red_write:set(key_hash, encrypted, "EX", ttl)
```
 
---
 
#### 4. `respond_from_cache` missing `ngx.exit()`
The function returned without finalizing the HTTP response, allowing nginx to continue into subsequent processing phases (`header_filter_by_lua`, etc.).
 
**After:**
```lua
return ngx.exit(ngx.status)
```
 
---
 
### ⚠️ Logic Issues Fixed
 
#### 5. `log.log_warn` used for normal flow
`log_warn("Backend request: ...")` on the cacheable backend request path was semantically incorrect — `WARN` is reserved for abnormal conditions. Changed to `log_info`.
 
#### 6. Local variable `treat_head_as_get` was ignored
The variable was declared at the top of `_M.handle()` but the non-cacheable block read `ngx.var.treat_head_as_get` directly again. Fixed to use the already-resolved local variable.
 
#### 7. Redundant cache eligibility check
The condition `if cache_methods[method] and cache_statuses[...]` re-checked `cache_methods[method]`, but that point in the code is only reached if the method is cacheable. Simplified to check only `i_own_lock` and `cache_statuses`.
 
---
 
### ℹ️ Quality Improvements
 
#### 8. Centralized `close_redis()` helper
```lua
local function close_redis(red_read, red_write)
    if red_read  then red_read:close()  end
    if red_write then red_write:close() end
end
```
Eliminates repetition and ensures safe closure (with nil guards) across all execution paths.
 
#### 9. Extracted `send_backend_response()` helper
The block that sends headers/status/body to the client was duplicated between the non-cacheable path and the main path. Extracted into a reusable function.
 
---
 
## `config/nginx.conf`
 
### 🐛 Bug Fixes
 
#### 1. Typo `BYBASS` → `BYPASS`
**Before:**
```nginx
set $cache_status "BYBASS";
```
**After:**
```nginx
set $cache_status "BYPASS";
```
The typo generated an invalid/phantom cache status value in Prometheus metrics.
 
---
 
#### 2. `init_worker_by_lua_block` — kept as required by `lua-resty-prometheus`
The `lua-resty-prometheus` library requires `init()` to be called in `init_worker_by_lua_block`. Each nginx worker must register its own internal counter state. Using `init_by_lua_block` (master process only) causes the `"counter not initialized!"` error on every metric call. This directive was **not changed**.
 
---